### PR TITLE
78 home page the title description text is not corresponded to the mockup in the home page what can you do block

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -23,7 +23,7 @@
   },
   "whatCanYouDo": {
     "title": "What can you do",
-    "description": "Whether you’re looking for a tutor or to looking become one – you’ve come to the right place.",
+    "description": "Whether you’re looking for a tutor or looking to become one – you’ve come to the right place.",
     "learn": {
       "title": "Learn from experts",
       "description": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout.established fact that a reader will be ",


### PR DESCRIPTION
Fixed a bug with the title description text on the home page.