### PR TITLE
Bug #75 fixed

### DIFF
--- a/src/constants/translations/en/guest-home-page.json
+++ b/src/constants/translations/en/guest-home-page.json
@@ -49,7 +49,7 @@
         "description": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout."
       },
       "sendRequest": {
-        "title": "Send Request",
+        "title": "Send a Request",
         "description": "It is a long established fact that a reader will be distracted by the readable content of a page when looking at its layout."
       },
       "startLearning": {

--- a/src/constants/translations/en/student-home-page.json
+++ b/src/constants/translations/en/student-home-page.json
@@ -21,7 +21,7 @@
       "description": "Choose your perfect tutor from over 10 000 teachers from all over the world."
     },
     "sendRequest": {
-      "title": "Send Request",
+      "title": "Send a Request",
       "description": "Describe what you would like to study and send a request to the tutor."
     },
     "startLearning": {


### PR DESCRIPTION
The “Send a Request” item in the student registration option at the home page “How it works” block is not corresponded to the mockup. This block appears in a student home page as well. I fixed this text issue in guest home page and student home page.

closes #75 