### PR TITLE
Bugfix #77 passwords do not match error

### DIFF
--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -25,6 +25,7 @@ const SignupForm = ({
   const { t } = useTranslation()
   const { privacyPolicy, termOfUse } = guestRoutes
   const [isAgreementChecked, setIsAgreementChecked] = useState(false)
+  const [confirmPasswordClicked, setConfirmPasswordClicked] = useState(false)
   const { inputVisibility: passwordVisibility, showInputText: showPassword } =
     useInputVisibility(errors.password)
   const {
@@ -36,6 +37,16 @@ const SignupForm = ({
   const handleOnAgreementChange = () => {
     setIsAgreementChecked((prev) => !prev)
   }
+
+  const handleOnInput = () => {
+    setConfirmPasswordClicked(true)
+  }
+
+  const confirmPasswordDoesNotMatchError =
+    confirmPasswordClicked &&
+    data.confirmPassword !== '' &&
+    data.password !== data.confirmPassword &&
+    t('common.errorMessages.passwordsDontMatch')
 
   const policyAgreement = (
     <Box sx={styles.box}>
@@ -117,9 +128,15 @@ const SignupForm = ({
       <AppTextField
         InputProps={confirmPasswordVisibility}
         fullWidth
+        helperText={
+          <span style={{ color: 'red' }}>
+            {confirmPasswordDoesNotMatchError}
+          </span>
+        }
         label={t('common.labels.confirmPassword')}
         onBlur={handleBlur('confirmPassword')}
         onChange={handleChange('confirmPassword')}
+        onInput={handleOnInput}
         required
         type={showConfirmPassword ? 'text' : 'password'}
         value={data.confirmPassword}


### PR DESCRIPTION
The bug is that the error message 'Passwords do not match' fails to appear when the 'Confirm Password' field does not match with inserted password in the Password Field.
The following code was implemented: 
-  created a state variable called confirmPasswordClicked with an initial value of false and a function setConfirmPasswordClicked to update its value
- created a function handleOnInput, that sets the state variable confirmPasswordClicked to true and it's called when "Confirm Password" field has been clicked(onInput={handleOnInput})
- created a variable confirmPasswordDoesNotMatchError which holds the error message: t('common.errorMessages.passwordsDontMatch') indicating that the passwords don't match, but only if the "Confirm Password" field has been interacted with and the passwords don't match. Otherwise, it remains undefined, indicating no error.
Please find below screenshot showing the result after the bug has been fixed:
![Untitled design-103](https://github.com/Space2Study-UA-1125/frontEnd/assets/66682491/271ba177-229d-4708-92d9-1237d2db346e)