### PR TITLE
76/bugfix/logo button does not return to the home page

### DIFF
--- a/src/containers/guest-home-page/Welcome.jsx
+++ b/src/containers/guest-home-page/Welcome.jsx
@@ -24,7 +24,11 @@ const Welcome = () => {
   }, [isLaptopAndAbove, isTablet, isMobile])
 
   return (
-    <Box className='section' sx={styles.container}>
+    <Box
+      className='section'
+      id={guestRoutes.welcome.route}
+      sx={styles.container}
+    >
       <Box alt='Title' component='img' src={image} sx={styles.title} />
       <Typography sx={styles.subtitle}>
         {t('guestHomePage.welcomeBlock.description')}

--- a/src/containers/layout/navbar/NavBar.jsx
+++ b/src/containers/layout/navbar/NavBar.jsx
@@ -30,6 +30,7 @@ const Navbar = () => {
   const { t } = useTranslation()
 
   const homePath = userRole ? guestRoutes[userRole].path : guestRoutes.home.path
+  const isOnHomePage = homePath === pathname
 
   const navigationItems = useMemo(() => {
     if (userRole === student) {
@@ -72,10 +73,10 @@ const Navbar = () => {
   return (
     <Box sx={styles.header}>
       <Button
-        component={Link}
+        component={isOnHomePage ? HashLink : Link}
         size={'small'}
         sx={styles.logoButton}
-        to={homePath}
+        to={isOnHomePage ? guestRoutes.welcome.path : homePath}
       >
         <Logo />
       </Button>

--- a/src/pages/guest-home-page/GuestHome.jsx
+++ b/src/pages/guest-home-page/GuestHome.jsx
@@ -47,6 +47,7 @@ const GuestHomePage = () => {
   return (
     <Box sx={styles.root}>
       <Welcome />
+
       <PageWrapper sx={styles.sectionsWrapper}>
         <FeatureBlock items={descriptionTimes} />
         <WhatCanYouDo />


### PR DESCRIPTION
The “Space2Study” logo button didn't return to the home page welcoming block after clicking it.

That should occure only when the client site is opened and user is not logged in

This bug a have fixed by adding to Welcome block id with route 'guestRoutes.welcome.route' (wich was created before)
Also in logo button (NavBar component) I've added HashLink to Wellcome component, wich works only if user is on Home page

According all this changes Logo button comes back to home-block but without scrollihg, only by route

Implementing this functionality by Context with scrolling throw all main+footer block was impossible for me, because Logo button renders before Welcome and can't receive ref from WelcomeContext (ref is null)

Video shows how button works now
https://www.loom.com/share/56cbfe436acf4587a121a4b3cffcebd8?sid=687c6cb5-3581-4fc7-8483-7581bbba98b1
