### PR TITLE
Add unit test for AppContentSwitcher component

### DIFF
--- a/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -2,6 +2,36 @@ import { screen, render, fireEvent } from '@testing-library/react'
 import { vi } from 'vitest'
 import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
 
+vi.mock('@mui/material', async () => {
+  const actual = await vi.importActual('@mui/material')
+  return {
+    ...actual,
+    Typography: vi.fn(({ children, sx }) => <p style={sx}>{children}</p>)
+  }
+})
+
+vi.mock('@mui/material/Stack', () => ({
+  default: vi.fn(({ children, sx }) => <div style={sx}>{children}</div>)
+}))
+
+vi.mock('@mui/material/Switch', () => ({
+  default: vi.fn(({ checked, onChange, sx }) => (
+    <input
+      checked={checked}
+      data-testid='switch'
+      onChange={onChange}
+      style={sx}
+      type='checkbox'
+    />
+  ))
+}))
+
+vi.mock('@mui/material/Tooltip', () => ({
+  default: vi.fn(({ title, children }) => (
+    <div aria-label={title}>{children}</div>
+  ))
+}))
+
 const onChange = vi.fn()
 
 const switchOptions = {

--- a/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
+++ b/tests/unit/components/app-content-switcher/AppContentSwitcher.spec.jsx
@@ -1,0 +1,60 @@
+import { screen, render, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import AppContentSwitcher from '~/components/app-content-switcher/AppContentSwitcher'
+
+const onChange = vi.fn()
+
+const switchOptions = {
+  left: {
+    text: 'Left Text',
+    tooltip: 'Left Tooltip'
+  },
+  right: {
+    text: 'Right Text',
+    tooltip: 'Right Tooltip'
+  }
+}
+
+describe('AppContentSwitcher component', () => {
+  const props = {
+    active: true,
+    onChange,
+    switchOptions,
+    typographyVariant: 'body1',
+    styles: {}
+  }
+
+  beforeEach(() => {
+    render(<AppContentSwitcher {...props} />)
+  })
+
+  it('should render correctly with props', () => {
+    const switchEl = screen.getByTestId('switch')
+    const switchCheckbox = screen.getByRole('checkbox')
+    const switchLeftOption = screen.getByText(props.switchOptions.left.text)
+    const switchRightOption = screen.getByText(props.switchOptions.right.text)
+
+    expect(switchEl).toBeInTheDocument()
+    expect(switchCheckbox).toHaveAttribute('checked')
+    expect(switchLeftOption).toBeInTheDocument()
+    expect(switchRightOption).toBeInTheDocument()
+  })
+
+  it('should call the function "onChange" when it was clicked on the switch', () => {
+    const switchCheckbox = screen.getByRole('checkbox')
+
+    fireEvent.click(switchCheckbox)
+
+    expect(onChange).toHaveBeenCalled()
+  })
+
+  it('should render tooltips if the tooltips props are passed', () => {
+    const leftTooltip = screen.getByLabelText(props.switchOptions.left.tooltip)
+    const rightTooltip = screen.getByLabelText(
+      props.switchOptions.right.tooltip
+    )
+
+    expect(leftTooltip).toBeInTheDocument()
+    expect(rightTooltip).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Unit test for "AppContentSwitcher" component
Scenaries descriptions:

 - Should render correctly with props
 - Should call the function "onChange" when it was clicked on the switch
 - Should render tooltips if the tooltips props are passed

<img width="851" alt="image" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/95382289-b613-4f09-809e-e5137292519e">
<img width="851" alt="image" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/e204daba-d7c8-4fef-b68d-c0e18a9d3a5e">

