### PR TITLE
Add unit test for inputWithIcon component

### DIFF
--- a/src/components/input-with-icon/InputWithIcon.jsx
+++ b/src/components/input-with-icon/InputWithIcon.jsx
@@ -7,7 +7,7 @@ import { styles } from '~/components/input-with-icon/InputWithIcon.styles'
 
 const InputWithIcon = ({ value, onClear, startIcon, sx, ...props }) => {
   return (
-    <Box sx={[styles.root, sx]}>
+    <Box data-testid='inputWithIconContainer' sx={[styles.root, sx]}>
       {startIcon}
       <InputBase sx={styles.input} value={value} {...props} />
       {value && (

--- a/tests/unit/components/input-with-icon/InputWithIcon.spec.jsx
+++ b/tests/unit/components/input-with-icon/InputWithIcon.spec.jsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import InputWithIcon from '~/components/input-with-icon/InputWithIcon'
+
+describe('InputWithIcon component', () => {
+    const propsWithValue = {
+        startIcon: <div data-testid='startIcon' />,
+        value: 'value'
+    }
+
+    const propsWithoutValue = {
+        startIcon: <div data-testid='startIcon' />,
+        value: ''
+    }
+
+    it('renders container', () => {
+        render(<InputWithIcon {...propsWithValue} />)
+        const inputWithIconContainer = screen.getByTestId('inputWithIconContainer')
+        expect(inputWithIconContainer).toBeInTheDocument()
+    })
+
+    it('renders start icon that is passed in props', () => {
+        render(<InputWithIcon {...propsWithValue} />)
+        const startIcon = screen.getByTestId('startIcon')
+        expect(startIcon).toBeInTheDocument()
+    })
+
+    it('renders inputBase', () => {
+        render(<InputWithIcon {...propsWithValue} />)
+        const inputBase = screen.getByRole('textbox')
+        expect(inputBase).toBeInTheDocument()
+    })
+
+    it('renders clear icon when input value is not empty', () => {
+        render(<InputWithIcon {...propsWithValue} />)
+        const clearIcon = screen.getByTestId('clearIcon')
+        expect(clearIcon).toBeInTheDocument()
+    })
+
+    it('does not render clear icon when input value is empty', () => {
+        render(<InputWithIcon {...propsWithoutValue} />)
+        const clearIcon = screen.queryByTestId('clearIcon')
+        expect(clearIcon).not.toBeInTheDocument()
+    })
+})


### PR DESCRIPTION
Unit test for "InputWithIcon" component
Scenaries descriptions:
 - Check if the "start" icon that was passed in props should be in the document
 -  If the value of input is not empty it should show "clear" icon


![Untitled design-104](https://github.com/Space2Study-UA-1125/frontEnd/assets/66682491/c4f82734-e93d-4a6b-a428-4fb48c11d7a0)



