### PR TITLE
Implement the validation for all the fields on the sign up form

### DIFF
--- a/src/constants/translations/en/common.json
+++ b/src/constants/translations/en/common.json
@@ -49,7 +49,7 @@
     "passwordLength": "Password cannot be shorter than 8 and longer than 25 characters",
     "passwordValid": "Password must contain at least one alphabetic and one numeric character",
     "emptyField": "This field cannot be empty",
-    "nameLength": "This field cannot be longer than 30 characters",
+    "nameLength": "This field cannot be shorter than 2 and longer than 15 characters",
     "nameAlphabeticOnly": "This field can contain alphabetic characters only",
     "passwordsDontMatch": "Passwords do not match",
     "shortText": "This text is too short",

--- a/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
+++ b/src/containers/guest-home-page/signup-dialog/SignupDialog.jsx
@@ -14,6 +14,13 @@ import GoogleLogin from '~/containers/guest-home-page/google-login/GoogleLogin'
 import NotificationModal from '~/containers/guest-home-page/notification-modal/NotificationModal'
 import SignupForm from '~/containers/guest-home-page/signup-form/SignupForm'
 import { signupUser } from '~/redux/reducer'
+import {
+  email,
+  password,
+  firstName,
+  lastName,
+  confirmPassword
+} from '~/utils/validations/login'
 
 import info from '~/assets/img/guest-home-page/info.svg'
 import student from '~/assets/img/signup-dialog/student.svg'
@@ -69,7 +76,8 @@ const SignupDialog = ({ type }) => {
       email: '',
       password: '',
       confirmPassword: ''
-    }
+    },
+    validations: { email, password, firstName, lastName, confirmPassword }
   })
 
   const description = (

--- a/src/containers/guest-home-page/signup-form/SignupForm.jsx
+++ b/src/containers/guest-home-page/signup-form/SignupForm.jsx
@@ -26,7 +26,6 @@ const SignupForm = ({
   const { t } = useTranslation()
   const { privacyPolicy, termOfUse } = guestRoutes
   const [isAgreementChecked, setIsAgreementChecked] = useState(false)
-  const [confirmPasswordClicked, setConfirmPasswordClicked] = useState(false)
   const { inputVisibility: passwordVisibility, showInputText: showPassword } =
     useInputVisibility(errors.password)
   const {
@@ -38,16 +37,6 @@ const SignupForm = ({
   const handleOnAgreementChange = () => {
     setIsAgreementChecked((prev) => !prev)
   }
-
-  const handleOnInput = () => {
-    setConfirmPasswordClicked(true)
-  }
-
-  const confirmPasswordDoesNotMatchError =
-    confirmPasswordClicked &&
-    data.confirmPassword !== '' &&
-    data.password !== data.confirmPassword &&
-    t('common.errorMessages.passwordsDontMatch')
 
   const policyAgreement = (
     <Box sx={styles.box}>
@@ -81,6 +70,7 @@ const SignupForm = ({
       <Box sx={{ display: { md: 'block', lg: 'flex' }, gap: '15px' }}>
         <AppTextField
           autoFocus
+          errorMsg={t(errors.firstName)}
           fullWidth
           label={t('common.labels.firstName')}
           onBlur={handleBlur('firstName')}
@@ -92,6 +82,7 @@ const SignupForm = ({
         />
 
         <AppTextField
+          errorMsg={t(errors.lastName)}
           fullWidth
           label={t('common.labels.lastName')}
           onBlur={handleBlur('lastName')}
@@ -104,6 +95,7 @@ const SignupForm = ({
       </Box>
 
       <AppTextField
+        errorMsg={t(errors.email)}
         fullWidth
         label={t('common.labels.email')}
         onBlur={handleBlur('email')}
@@ -116,6 +108,7 @@ const SignupForm = ({
 
       <AppTextField
         InputProps={passwordVisibility}
+        errorMsg={t(errors.password)}
         fullWidth
         label={t('common.labels.password')}
         onBlur={handleBlur('password')}
@@ -128,16 +121,11 @@ const SignupForm = ({
 
       <AppTextField
         InputProps={confirmPasswordVisibility}
+        errorMsg={t(errors.confirmPassword)}
         fullWidth
-        helperText={
-          <span style={{ color: 'red' }}>
-            {confirmPasswordDoesNotMatchError}
-          </span>
-        }
         label={t('common.labels.confirmPassword')}
         onBlur={handleBlur('confirmPassword')}
         onChange={handleChange('confirmPassword')}
-        onInput={handleOnInput}
         required
         type={showConfirmPassword ? 'text' : 'password'}
         value={data.confirmPassword}

--- a/src/utils/validations/common.js
+++ b/src/utils/validations/common.js
@@ -1,6 +1,6 @@
 const validations = {
   nameField: (value) => {
-    if (value.length > 30) {
+    if (value.length < 2 || value.length > 15) {
       return 'common.errorMessages.nameLength'
     }
     if (!RegExp(/^[a-zа-яєії ]+$/i).test(value)) {

--- a/src/utils/validations/login.js
+++ b/src/utils/validations/login.js
@@ -20,6 +20,6 @@ export const confirmPassword = (password, data) => {
   return emptyField(
     password,
     'common.errorMessages.emptyField',
-    password !== data.password ? 'common.errorMessages.emptyField' : ''
+    password !== data.password ? 'common.errorMessages.passwordsDontMatch' : ''
   )
 }


### PR DESCRIPTION
Implement the validation for all the fields on the sign up form according to the issue #127:
 - "First Name" and "Last Name" fields must receive a string in a range from 2 to 15 symbols.
 - The email field must be for emails.
 - Password must contain at least one alphabetic and one numeric character.
 - The "Confirm Password" field must be connected with the "Password" field.

Pull the branch to test the changes:
```bash
git pull origin feature/127/sign-up-form-fields-validation
```

<img width="1078" alt="image" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/952961b3-dc56-4f7e-8f2d-2c3750cbb206">
