### PR TITLE
Feature/#151/sp 2 add language step

### DIFF
--- a/src/containers/tutor-home-page/language-step/LanguageStep.jsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.jsx
@@ -1,12 +1,22 @@
+import { Typography } from '@mui/material'
 import Box from '@mui/material/Box'
-
+// import { languages } from './constants'
+import languageStepImg from '~/assets/img/tutor-home-page/become-tutor/languages.svg'
 import { styles } from '~/containers/tutor-home-page/language-step/LanguageStep.styles'
 
 const LanguageStep = ({ btnsBox }) => {
   return (
     <Box sx={styles.container}>
-      Language step
-      {btnsBox}
+      <Box sx={styles.image}>
+        <img alt='Language Step Image' src={languageStepImg} />
+      </Box>
+      <Box>
+        <Typography sx={styles.infoContainer}>
+          Velit officia consequat duis enim velit mollit. Other categories you
+          can add in your account settings later.
+        </Typography>
+        {btnsBox}
+      </Box>
     </Box>
   )
 }

--- a/src/containers/tutor-home-page/language-step/LanguageStep.jsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.jsx
@@ -9,16 +9,14 @@ import {
 } from '@mui/material'
 import ClearRoundedIcon from '@mui/icons-material/ClearRounded'
 import { languages } from './constants'
-import translations from '~/constants/translations/en/become-tutor.json'
+import { useTranslation } from 'react-i18next'
 import languageStepImg from '~/assets/img/tutor-home-page/become-tutor/languages.svg'
 import { styles } from '~/containers/tutor-home-page/language-step/LanguageStep.styles'
 import { useState } from 'react'
 
-const {
-  languages: { title, autocompleteLabel }
-} = translations
-
 const LanguageStep = ({ btnsBox }) => {
+  const { t } = useTranslation()
+
   const [selectedLanguage, setSelectedLanguage] = useState('')
 
   const handleChange = (event) => {
@@ -40,7 +38,9 @@ const LanguageStep = ({ btnsBox }) => {
       </Box>
       <Box sx={styles.infoWrapper}>
         <Box>
-          <Typography sx={styles.infoDescription}>{title}</Typography>
+          <Typography sx={styles.infoDescription}>
+            {t('becomeTutor.languages.title')}
+          </Typography>
           <Box sx={styles.smallLanguageImage}>
             <img
               alt='Language Step Image'
@@ -50,7 +50,7 @@ const LanguageStep = ({ btnsBox }) => {
           </Box>
           <FormControl fullWidth>
             <InputLabel id='nativeLanguageLabel'>
-              {autocompleteLabel}
+              {t('becomeTutor.languages.autocompleteLabel')}
             </InputLabel>
             <Select
               endAdornment={
@@ -66,7 +66,7 @@ const LanguageStep = ({ btnsBox }) => {
                 )
               }
               id='nativeLanguageSelect'
-              label={autocompleteLabel}
+              label={t('becomeTutor.languages.autocompleteLabel')}
               labelId='nativeLanguageLabel'
               onChange={handleChange}
               value={selectedLanguage}

--- a/src/containers/tutor-home-page/language-step/LanguageStep.jsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.jsx
@@ -1,21 +1,85 @@
-import { Typography } from '@mui/material'
-import Box from '@mui/material/Box'
-// import { languages } from './constants'
+import {
+  Box,
+  FormControl,
+  IconButton,
+  InputLabel,
+  MenuItem,
+  Select,
+  Typography
+} from '@mui/material'
+import ClearRoundedIcon from '@mui/icons-material/ClearRounded'
+import { languages } from './constants'
+import translations from '~/constants/translations/en/become-tutor.json'
 import languageStepImg from '~/assets/img/tutor-home-page/become-tutor/languages.svg'
 import { styles } from '~/containers/tutor-home-page/language-step/LanguageStep.styles'
+import { useState } from 'react'
+
+const {
+  languages: { title, autocompleteLabel }
+} = translations
 
 const LanguageStep = ({ btnsBox }) => {
+  const [selectedLanguage, setSelectedLanguage] = useState('')
+
+  const handleChange = (event) => {
+    setSelectedLanguage(event.target.value)
+  }
+
+  const handleClear = () => {
+    setSelectedLanguage('')
+  }
+
   return (
     <Box sx={styles.container}>
-      <Box sx={styles.image}>
-        <img alt='Language Step Image' src={languageStepImg} />
+      <Box sx={styles.languageImage}>
+        <img
+          alt='Language Step Image'
+          src={languageStepImg}
+          style={styles.img}
+        />
       </Box>
-      <Box>
-        <Typography sx={styles.infoContainer}>
-          Velit officia consequat duis enim velit mollit. Other categories you
-          can add in your account settings later.
-        </Typography>
-        {btnsBox}
+      <Box sx={styles.infoWrapper}>
+        <Box>
+          <Typography sx={styles.infoDescription}>{title}</Typography>
+          <Box sx={styles.smallLanguageImage}>
+            <img
+              alt='Language Step Image'
+              src={languageStepImg}
+              style={styles.img}
+            />
+          </Box>
+          <FormControl fullWidth>
+            <InputLabel id='nativeLanguageLabel'>
+              {autocompleteLabel}
+            </InputLabel>
+            <Select
+              endAdornment={
+                selectedLanguage && (
+                  <IconButton
+                    aria-label='Clear'
+                    edge='end'
+                    onClick={handleClear}
+                    sx={styles.clearIconButton}
+                  >
+                    <ClearRoundedIcon />
+                  </IconButton>
+                )
+              }
+              id='nativeLanguageSelect'
+              label={autocompleteLabel}
+              labelId='nativeLanguageLabel'
+              onChange={handleChange}
+              value={selectedLanguage}
+            >
+              {languages.map((language) => (
+                <MenuItem key={language} value={language}>
+                  {language}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Box>
+        <Box>{btnsBox}</Box>
       </Box>
     </Box>
   )

--- a/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
@@ -8,11 +8,33 @@ export const styles = {
     height: { sm: '485px' },
     ...fadeAnimation
   },
-  image: {
-    maxWidth: '395',
-    maxheight: '440'
+  languageImage: {
+    maxWidth: { md: '295px', lg: '378px' },
+    maxHeight: { md: '345px', lg: '440px' },
+    display: { xs: 'none', md: 'block' }
   },
-  infoContainer: {
-    maxWidth: '432px'
+  smallLanguageImage: {
+    maxWidth: { xs: '180px' },
+    maxHeight: { xs: '200px' },
+    display: { xs: 'block', md: 'none' },
+    margin: '0 auto',
+    marginBottom: '20px '
+  },
+  img: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover'
+  },
+  infoWrapper: {
+    maxWidth: '432px',
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between'
+  },
+  infoDescription: {
+    marginBottom: '20px'
+  },
+  clearIconButton: {
+    marginRight: '12px'
   }
 }

--- a/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.styles.js
@@ -7,5 +7,12 @@ export const styles = {
     gap: '40px',
     height: { sm: '485px' },
     ...fadeAnimation
+  },
+  image: {
+    maxWidth: '395',
+    maxheight: '440'
+  },
+  infoContainer: {
+    maxWidth: '432px'
   }
 }

--- a/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -46,6 +46,6 @@ describe('LanguageStep test', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /clear/i }))
 
-    expect(screen.getByDisplayValue('')).toBeInTheDocument()
+    expect(screen.queryByDisplayValue('English')).toBeNull()
   })
 })

--- a/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -1,10 +1,5 @@
 import { cleanup, render, screen, fireEvent } from '@testing-library/react'
 import LanguageStep from '~/containers/tutor-home-page/language-step/LanguageStep'
-import translations from '~/constants/translations/en/become-tutor.json'
-
-const {
-  languages: { title, autocompleteLabel }
-} = translations
 
 const mockBtnsBox = <div>Mock Buttons Box</div>
 
@@ -14,8 +9,10 @@ beforeEach(() => {
 })
 
 it('renders LanguageStep component with translated title and label', () => {
-  expect(screen.getByText(title)).toBeInTheDocument()
-  expect(screen.getByLabelText(autocompleteLabel)).toBeInTheDocument()
+  expect(screen.getByText('becomeTutor.languages.title')).toBeInTheDocument()
+  expect(
+    screen.getByLabelText('becomeTutor.languages.autocompleteLabel')
+  ).toBeInTheDocument()
 })
 
 it('renders LanguageStep component without selected language', () => {
@@ -25,7 +22,9 @@ it('renders LanguageStep component without selected language', () => {
 })
 
 it('renders LanguageStep component with selected language', () => {
-  const selectElement = screen.getByLabelText(autocompleteLabel)
+  const selectElement = screen.getByLabelText(
+    'becomeTutor.languages.autocompleteLabel'
+  )
   fireEvent.mouseDown(selectElement)
   fireEvent.click(screen.getByText('English'))
   fireEvent.mouseUp(selectElement)
@@ -34,7 +33,9 @@ it('renders LanguageStep component with selected language', () => {
 })
 
 it('clears the selected language on clear button click', () => {
-  const selectElement = screen.getByLabelText(autocompleteLabel)
+  const selectElement = screen.getByLabelText(
+    'becomeTutor.languages.autocompleteLabel'
+  )
 
   fireEvent.mouseDown(selectElement)
   fireEvent.click(screen.getByText('English'))

--- a/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -3,47 +3,49 @@ import LanguageStep from '~/containers/tutor-home-page/language-step/LanguageSte
 
 const mockBtnsBox = <div>Mock Buttons Box</div>
 
-beforeEach(() => {
-  cleanup()
-  render(<LanguageStep btnsBox={mockBtnsBox} />)
-})
+describe('LanguageStep test', () => {
+  beforeEach(() => {
+    cleanup()
+    render(<LanguageStep btnsBox={mockBtnsBox} />)
+  })
 
-it('renders LanguageStep component with translated title and label', () => {
-  expect(screen.getByText('becomeTutor.languages.title')).toBeInTheDocument()
-  expect(
-    screen.getByLabelText('becomeTutor.languages.autocompleteLabel')
-  ).toBeInTheDocument()
-})
+  it('renders LanguageStep component with translated title and label', () => {
+    expect(screen.getByText('becomeTutor.languages.title')).toBeInTheDocument()
+    expect(
+      screen.getByLabelText('becomeTutor.languages.autocompleteLabel')
+    ).toBeInTheDocument()
+  })
 
-it('renders LanguageStep component without selected language', () => {
-  expect(
-    screen.queryByRole('button', { name: /clear/i })
-  ).not.toBeInTheDocument()
-})
+  it('renders LanguageStep component without selected language', () => {
+    expect(
+      screen.queryByRole('button', { name: /clear/i })
+    ).not.toBeInTheDocument()
+  })
 
-it('renders LanguageStep component with selected language', () => {
-  const selectElement = screen.getByLabelText(
-    'becomeTutor.languages.autocompleteLabel'
-  )
-  fireEvent.mouseDown(selectElement)
-  fireEvent.click(screen.getByText('English'))
-  fireEvent.mouseUp(selectElement)
+  it('renders LanguageStep component with selected language', () => {
+    const selectElement = screen.getByLabelText(
+      'becomeTutor.languages.autocompleteLabel'
+    )
+    fireEvent.mouseDown(selectElement)
+    fireEvent.click(screen.getByText('English'))
+    fireEvent.mouseUp(selectElement)
 
-  expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
-})
+    expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+  })
 
-it('clears the selected language on clear button click', () => {
-  const selectElement = screen.getByLabelText(
-    'becomeTutor.languages.autocompleteLabel'
-  )
+  it('clears the selected language on clear button click', () => {
+    const selectElement = screen.getByLabelText(
+      'becomeTutor.languages.autocompleteLabel'
+    )
 
-  fireEvent.mouseDown(selectElement)
-  fireEvent.click(screen.getByText('English'))
-  fireEvent.mouseUp(selectElement)
+    fireEvent.mouseDown(selectElement)
+    fireEvent.click(screen.getByText('English'))
+    fireEvent.mouseUp(selectElement)
 
-  expect(screen.getByDisplayValue('English')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('English')).toBeInTheDocument()
 
-  fireEvent.click(screen.getByRole('button', { name: /clear/i }))
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }))
 
-  expect(screen.getByDisplayValue('')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('')).toBeInTheDocument()
+  })
 })

--- a/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -1,0 +1,48 @@
+import { cleanup, render, screen, fireEvent } from '@testing-library/react'
+import LanguageStep from '~/containers/tutor-home-page/language-step/LanguageStep'
+import translations from '~/constants/translations/en/become-tutor.json'
+
+const {
+  languages: { title, autocompleteLabel }
+} = translations
+
+const mockBtnsBox = <div>Mock Buttons Box</div>
+
+beforeEach(() => {
+  cleanup()
+  render(<LanguageStep btnsBox={mockBtnsBox} />)
+})
+
+it('renders LanguageStep component with translated title and label', () => {
+  expect(screen.getByText(title)).toBeInTheDocument()
+  expect(screen.getByLabelText(autocompleteLabel)).toBeInTheDocument()
+})
+
+it('renders LanguageStep component without selected language', () => {
+  expect(
+    screen.queryByRole('button', { name: /clear/i })
+  ).not.toBeInTheDocument()
+})
+
+it('renders LanguageStep component with selected language', () => {
+  const selectElement = screen.getByLabelText(autocompleteLabel)
+  fireEvent.mouseDown(selectElement)
+  fireEvent.click(screen.getByText('English'))
+  fireEvent.mouseUp(selectElement)
+
+  expect(screen.getByRole('button', { name: /clear/i })).toBeInTheDocument()
+})
+
+it('clears the selected language on clear button click', () => {
+  const selectElement = screen.getByLabelText(autocompleteLabel)
+
+  fireEvent.mouseDown(selectElement)
+  fireEvent.click(screen.getByText('English'))
+  fireEvent.mouseUp(selectElement)
+
+  expect(screen.getByDisplayValue('English')).toBeInTheDocument()
+
+  fireEvent.click(screen.getByRole('button', { name: /clear/i }))
+
+  expect(screen.getByDisplayValue('')).toBeInTheDocument()
+})


### PR DESCRIPTION
Implemented LanguageStep component for stepper:
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/90631981-275f-45ac-90ad-f8f436940b54)

When user click on select it fetch existing languages:
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/6cd76978-7949-4a84-b547-1aabb4e07213)

When user click on criss-cross it remove select field value:
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/82bf1a3d-6564-45b6-87d1-c31f090d0192)


Component is adaptive for different screen sizes, following markup:

phone:
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/39cf48d1-138a-4122-a518-aa86b388088c)

tablet:
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/aa1b5a09-83e9-4cbf-bd6e-8569577e7232)

Tests:
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/3dc3934f-7316-4f03-a5fa-2ef68b8c9878)
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/e47e27ef-dd6a-45d8-aad7-35c3edabfd82)

