### PR TITLE
Feature/143/add button and chips to subjects step

### DIFF
--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -98,7 +98,8 @@ const SubjectsStep = ({ btnsBox }) => {
             {t('becomeTutor.categories.btnText')}
           </AppButton>
           <FormHelperText error={subjectsError !== null}>
-            {subjectsError || null}
+            {subjectsError}
+
           </FormHelperText>
 
           <AppChipList

--- a/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
+++ b/src/containers/tutor-home-page/subjects-step/SubjectsStep.jsx
@@ -2,7 +2,8 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-
+import AppChipList from '~/components/app-chips-list/AppChipList'
+import FormHelperText from '@mui/material/FormHelperText'
 import studyCategory from '~/assets/img/tutor-home-page/become-tutor/study-category.svg'
 import AppButton from '~/components/app-button/AppButton'
 import AsyncAutocomplete from '~/components/async-autocomlete/AsyncAutocomplete'
@@ -16,7 +17,8 @@ const SubjectsStep = ({ btnsBox }) => {
   const { t } = useTranslation()
   const [category, setCategory] = useState(null)
   const [subject, setSubject] = useState(null)
-
+  const [selectedSubjects, setSelectedSubjects] = useState([])
+  const [subjectsError, setSubjectsError] = useState(null)
   const categoryTextFieldProps = {
     label: t('becomeTutor.categories.mainSubjectsLabel')
   }
@@ -29,9 +31,34 @@ const SubjectsStep = ({ btnsBox }) => {
     : getEmptyArrayData
 
   const handleCategoryChange = (value) => {
+    setSubjectsError(null)
     setCategory(value)
     setSubject(null)
   }
+  const handleSubjectChange = (value) => {
+    setSubjectsError(null)
+    setSubject(value)
+  }
+  const handleAddSubject = () => {
+    if (subject) {
+      const isTheSameSubjectSelected = selectedSubjects.some(
+        (selectedSubject) => subject._id === selectedSubject._id
+      )
+      if (isTheSameSubjectSelected) {
+        setSubjectsError(t('becomeTutor.categories.sameSubject'))
+        setSubject(null)
+      } else {
+        setSelectedSubjects([...selectedSubjects, subject])
+        setSubject(null)
+      }
+    }
+  }
+  const handleDeleteSubject = (chip) => {
+    setSelectedSubjects(
+      selectedSubjects.filter((subject) => subject.name !== chip)
+    )
+  }
+  const selectedSubjectsNames = selectedSubjects.map((subject) => subject.name)
 
   return (
     <Box sx={styles.container}>
@@ -56,7 +83,7 @@ const SubjectsStep = ({ btnsBox }) => {
           />
           <AsyncAutocomplete
             labelField='name'
-            onChange={(_e, newValue) => setSubject(newValue)}
+            onChange={(_e, newValue) => handleSubjectChange(newValue)}
             service={currentSubjectService}
             textFieldProps={subjectTextFieldProps}
             value={subject ? subject._id : null}
@@ -64,11 +91,21 @@ const SubjectsStep = ({ btnsBox }) => {
           />
           <AppButton
             disabled={!subject}
+            onClick={handleAddSubject}
             sx={styles.addSubjectBtn}
             variant={'tonal'}
           >
             {t('becomeTutor.categories.btnText')}
           </AppButton>
+          <FormHelperText error={subjectsError !== null}>
+            {subjectsError || null}
+          </FormHelperText>
+
+          <AppChipList
+            defaultQuantity={2}
+            handleChipDelete={handleDeleteSubject}
+            items={selectedSubjectsNames}
+          />
         </Box>
         {btnsBox}
       </Box>

--- a/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/subjects-step/SubjectsStep.spec.jsx
@@ -44,8 +44,8 @@ vi.mock('@mui/material/Typography', () => ({
 }))
 
 vi.mock('~/components/app-button/AppButton', () => ({
-  default: vi.fn(({ children, sx }) => (
-    <button style={sx} type='button'>
+  default: vi.fn(({ children, sx, onClick }) => (
+    <button onClick={onClick} style={sx} type='button'>
       {children}
     </button>
   ))
@@ -142,5 +142,83 @@ describe('SubjectsStep renders components', () => {
 
     expect(categoryField).toHaveValue('')
     expect(subjectField).toHaveValue('')
+  })
+  it('should add subject when clicking the add button', async () => {
+    const categoryField = screen.getByLabelText(
+      'becomeTutor.categories.mainSubjectsLabel'
+    )
+    const subjectField = screen.getByLabelText(
+      'becomeTutor.categories.subjectLabel'
+    )
+    const addButton = screen.getByText('becomeTutor.categories.btnText')
+
+    userEvent.click(categoryField)
+    userEvent.click(screen.getByText('Category 1'))
+    userEvent.click(subjectField)
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Subject 1'))
+    })
+
+    userEvent.click(addButton)
+
+    const chip = screen.queryByTestId('chip')
+    expect(chip).toHaveTextContent('Subject 1')
+  })
+
+  it('should show error message when the same subject is added', async () => {
+    const categoryField = screen.getByLabelText(
+      'becomeTutor.categories.mainSubjectsLabel'
+    )
+    const subjectField = screen.getByLabelText(
+      'becomeTutor.categories.subjectLabel'
+    )
+    const addButton = screen.getByText('becomeTutor.categories.btnText')
+
+    //first add
+    userEvent.click(categoryField)
+    userEvent.click(screen.getByText('Category 1'))
+    await waitFor(() => {
+      userEvent.click(subjectField)
+    })
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Subject 1'))
+    })
+    userEvent.click(addButton)
+    const chip = screen.queryByTestId('chip')
+    expect(chip).toHaveTextContent('Subject 1')
+    //second add
+    userEvent.click(subjectField)
+    await waitFor(() => {
+      userEvent.click(screen.getAllByText('Subject 1')[1])
+    })
+    userEvent.click(addButton)
+    expect(
+      screen.getByText('becomeTutor.categories.sameSubject')
+    ).toBeInTheDocument()
+  })
+
+  it('should delete subject when clicking on the delete icon', async () => {
+    const categoryField = screen.getByLabelText(
+      'becomeTutor.categories.mainSubjectsLabel'
+    )
+    const subjectField = screen.getByLabelText(
+      'becomeTutor.categories.subjectLabel'
+    )
+    const addButton = screen.getByText('becomeTutor.categories.btnText')
+
+    userEvent.click(categoryField)
+    userEvent.click(screen.getByText('Category 1'))
+    await waitFor(() => {
+      userEvent.click(subjectField)
+    })
+    await waitFor(() => {
+      userEvent.click(screen.getByText('Subject 1'))
+    })
+    userEvent.click(addButton)
+
+    const deleteButton = screen.getByTestId('close-btn')
+    userEvent.click(deleteButton)
+
+    expect(screen.queryByText('Subject 1')).toBeNull()
   })
 })


### PR DESCRIPTION
Implemented chips for Subjects and covered it with unit tests according to mockup. 
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/126193367/653e6762-0ab1-48a2-a2b1-b167c98bb26c)
## Acceptance Criteria
- [x] When a user selects a subject and clicks on the button "Add one more subject" it should create a new chip with the selected subject
- [x] When the user has selected 3rd or more subjects it should be shown by increasing values of the rest selected subjects
- [x] When the user has selected the same subject that already exists an error should be created and the error's message should be shown.
Coverage for SubjectsStep component is 100%.
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/126193367/d4aa2d17-40b0-423f-b2c0-5ab2221f385c)
Also all of the unit tests passed.
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/126193367/dfb56604-b5ec-4241-a0eb-1b156c2220f4)

https://www.loom.com/share/37f528962a9141b99fead0f218a80e67?sid=308b0b78-f163-4d65-a09c-b18b01463bf2