### PR TITLE
Create a hook to set URL search parameters 

### DIFF
--- a/src/hooks/use-url-search-params.jsx
+++ b/src/hooks/use-url-search-params.jsx
@@ -1,0 +1,29 @@
+import { useSearchParams } from 'react-router-dom'
+
+const useUrlSearchParams = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const setUrlSearchParams = (params) => {
+    setSearchParams((prev) => {
+      for (const paramName in params) {
+        const paramValue = params[paramName]
+
+        const paramValueToString = Array.isArray(paramValue)
+          ? paramValue.join(',')
+          : paramValue
+
+        if (paramValueToString) {
+          prev.set(paramName, paramValueToString)
+        } else {
+          prev.delete(paramName)
+        }
+      }
+
+      return prev
+    })
+  }
+
+  return { searchParams, setUrlSearchParams }
+}
+
+export default useUrlSearchParams

--- a/tests/unit/hooks/use-url-search-params.spec.jsx
+++ b/tests/unit/hooks/use-url-search-params.spec.jsx
@@ -1,0 +1,30 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+import { BrowserRouter } from 'react-router-dom'
+import useUrlSearchParams from '~/hooks/use-url-search-params'
+
+describe('useUrlSearchParams', () => {
+  it('should set and get search parameters correctly', () => {
+    const { result } = renderHook(() => useUrlSearchParams(), {
+      wrapper: BrowserRouter
+    })
+
+    act(() => {
+      result.current.setUrlSearchParams({
+        view: 'grid',
+        category: ['category1', 'category2']
+      })
+    })
+
+    expect(result.current.searchParams.get('view')).toBe('grid')
+    expect(result.current.searchParams.get('category')).toEqual(
+      'category1,category2'
+    )
+
+    act(() => {
+      result.current.setUrlSearchParams({ view: 'list', category: '' })
+    })
+
+    expect(result.current.searchParams.get('view')).toBe('list')
+    expect(result.current.searchParams.has('category')).toBe(false)
+  })
+})


### PR DESCRIPTION
Created a custom hook to set URL search parameters.

The parameters must be passed as an object, where the key is the name of the parameter and the value is the value of the parameter. The value can be a string or an array of strings.

For example:

```javascript
setUrlSearchParams({ view: 'grid' })
// or
setUrlSearchParams({ view: 'grid', category: 'languages' })
```

<img width="559" alt="image" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/4b397959-8c56-42a5-a594-9308cfa52916">
<img width="607" alt="image" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/ab4c6ce0-93fe-42a0-ada7-1d8a28669243">

Test results:

<img width="765" alt="Screenshot 2024-02-29 at 00 25 00" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/c458a375-a18c-4f28-a21f-1ef7b2846241">

<img width="887" alt="Screenshot 2024-02-29 at 00 25 17" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/7f45e2a5-6291-461d-ba61-e63a1958b2db">
