### PR TITLE
Feature/171/sp 1 find offers make a container for cards

### DIFF
--- a/src/components/offer-card/OfferCard.jsx
+++ b/src/components/offer-card/OfferCard.jsx
@@ -1,0 +1,3 @@
+const OfferCard = () => {}
+
+export default OfferCard

--- a/src/containers/offers-container/OffersContainer.jsx
+++ b/src/containers/offers-container/OffersContainer.jsx
@@ -1,0 +1,17 @@
+import { Grid } from '@mui/material'
+import { styles } from '~/containers/offers-container/OffersContainer.styles'
+import OfferCard from './OfferCard'
+
+const OffersContainer = ({ offers, view = 'list' }) => {
+  return (
+    <Grid container sx={view === 'grid' ? styles.grid : styles.list}>
+      {offers.map((offer) => (
+        <Grid item key={offer.id}>
+          <OfferCard offer={offer} view={view}></OfferCard>
+        </Grid>
+      ))}
+    </Grid>
+  )
+}
+
+export default OffersContainer

--- a/src/containers/offers-container/OffersContainer.jsx
+++ b/src/containers/offers-container/OffersContainer.jsx
@@ -1,6 +1,6 @@
 import { Grid } from '@mui/material'
 import { styles } from '~/containers/offers-container/OffersContainer.styles'
-import OfferCard from './OfferCard'
+import OfferCard from '~/components/offer-card/OfferCard'
 
 const OffersContainer = ({ offers, view = 'list' }) => {
   return (

--- a/src/containers/offers-container/OffersContainer.styles.js
+++ b/src/containers/offers-container/OffersContainer.styles.js
@@ -1,0 +1,11 @@
+export const styles = {
+  grid: {
+    justifyContent: 'center',
+    gap: '32px 24px',
+    gridTemplateColumns: 'repeat(3, 1fr)'
+  },
+  list: {
+    justifyContent: 'center',
+    gap: '16px'
+  }
+}

--- a/tests/unit/containers/offers-container/OffersContainer.spec.jsx
+++ b/tests/unit/containers/offers-container/OffersContainer.spec.jsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import OffersContainer from '~/containers/offers-container/OffersContainer'
+import { styles } from '~/containers/offers-container/OffersContainer.styles'
+
+vi.mock('~/components/offer-card/OfferCard', () => {
+  return {
+    __esModules: true,
+    default: () => <div data-testid='mock-offer-card'>Mocked Offer Card</div>
+  }
+})
+
+describe('OffersContainer test', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders offer cards', () => {
+    const mockOffers = [
+      {
+        id: 1,
+        title: 'Offer 1',
+        description: 'Description 1'
+      },
+      {
+        id: 2,
+        title: 'Offer 2',
+        description: 'Description 2'
+      },
+      {
+        id: 2,
+        title: 'Offer 3',
+        description: 'Description 3'
+      }
+    ]
+    render(<OffersContainer offers={mockOffers} view='grid' />)
+
+    expect(screen.getAllByTestId('mock-offer-card')).toHaveLength(
+      mockOffers.length
+    )
+  })
+
+  it('applies grid styles for grid view', () => {
+    const { container } = render(<OffersContainer offers={[]} view='grid' />)
+
+    const containerStyles = getComputedStyle(container.firstChild)
+
+    expect(containerStyles.getPropertyValue('grid-template-columns')).toBe(
+      styles.grid.gridTemplateColumns
+    )
+    expect(containerStyles.getPropertyValue('justify-content')).toBe(
+      styles.grid.justifyContent
+    )
+    expect(containerStyles.getPropertyValue('gap')).toBe(styles.grid.gap)
+  })
+
+  it('applies list styles for list view', () => {
+    const { container } = render(<OffersContainer offers={[]} view='list' />)
+
+    const containerStyles = getComputedStyle(container.firstChild)
+
+    expect(containerStyles.getPropertyValue('justify-content')).toBe(
+      styles.list.justifyContent
+    )
+    expect(containerStyles.getPropertyValue('gap')).toBe(styles.list.gap)
+  })
+})


### PR DESCRIPTION
I did a container for Offers, its flexible for future using.
To have a visual test I mocked future components:
We have 2 possible views: 

list:
![Знімок екрана 2024-03-01 155746](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/26952185-3ee6-489f-a979-5061f132d6ae)

grid:
![Знімок екрана 2024-03-01 155726](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/11189342-45c1-4557-8b32-3e8e2cacac25)


  The component is covered by tests.
  Small notice: I couldn't test, or mock non-existing component OfferCard, so I just created an empty one, then mocked it in tests
  
![image](https://github.com/Space2Study-UA-1125/frontEnd/assets/60313835/30e42b8c-5133-4101-977f-38af507ea3ea)
