### PR TITLE
Add fetching languages from backend

### DIFF
--- a/src/constants/request.js
+++ b/src/constants/request.js
@@ -39,5 +39,8 @@ export const URLs = {
     get: '/cooperations',
     create: '/cooperations',
     update: '/cooperations'
+  },
+  languages: {
+    get: '/languages'
   }
 }

--- a/src/containers/tutor-home-page/language-step/LanguageStep.jsx
+++ b/src/containers/tutor-home-page/language-step/LanguageStep.jsx
@@ -8,18 +8,29 @@ import {
   Typography
 } from '@mui/material'
 import ClearRoundedIcon from '@mui/icons-material/ClearRounded'
-import { languages } from './constants'
 import { useTranslation } from 'react-i18next'
 import languageStepImg from '~/assets/img/tutor-home-page/become-tutor/languages.svg'
 import { styles } from '~/containers/tutor-home-page/language-step/LanguageStep.styles'
 import { useState, useEffect } from 'react'
 import { useStepContext } from '~/context/step-context'
+import { languageService } from '~/services/language-service'
+import { defaultResponses } from '~/constants'
+import useAxios from '~/hooks/use-axios'
 
 const LanguageStep = ({ btnsBox, stepLabel }) => {
   const { stepData, handleStepData } = useStepContext()
   const { t } = useTranslation()
 
   const [selectedLanguage, setSelectedLanguage] = useState(stepData[stepLabel])
+
+  useEffect(() => {
+    handleStepData(stepLabel, selectedLanguage)
+  }, [selectedLanguage, stepLabel, handleStepData])
+
+  const { response } = useAxios({
+    service: languageService.getLanguages,
+    defaultResponse: defaultResponses.array
+  })
 
   const handleChange = (event) => {
     setSelectedLanguage(event.target.value)
@@ -28,9 +39,7 @@ const LanguageStep = ({ btnsBox, stepLabel }) => {
   const handleClear = () => {
     setSelectedLanguage('')
   }
-  useEffect(() => {
-    handleStepData(stepLabel, selectedLanguage)
-  }, [selectedLanguage, stepLabel, handleStepData])
+
   return (
     <Box sx={styles.container}>
       <Box sx={styles.languageImage}>
@@ -75,7 +84,7 @@ const LanguageStep = ({ btnsBox, stepLabel }) => {
               onChange={handleChange}
               value={selectedLanguage}
             >
-              {languages.map((language) => (
+              {response.map((language) => (
                 <MenuItem key={language} value={language}>
                   {language}
                 </MenuItem>

--- a/src/context/step-context.jsx
+++ b/src/context/step-context.jsx
@@ -8,7 +8,7 @@ const StepProvider = ({ children, initialValues, stepLabels }) => {
     errors: {}
   })
   const [subject, setSubject] = useState([])
-  const [language, setLanguage] = useState(null)
+  const [language, setLanguage] = useState('')
   const [photo, setPhoto] = useState([])
   const [generalLabel, subjectLabel, languageLabel, photoLabel] = stepLabels
 

--- a/src/services/language-service.js
+++ b/src/services/language-service.js
@@ -1,0 +1,9 @@
+import { axiosClient } from '~/plugins/axiosClient'
+
+import { URLs } from '~/constants/request'
+
+export const languageService = {
+  getLanguages: () => {
+    return axiosClient.get(URLs.languages.get)
+  }
+}

--- a/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
+++ b/tests/unit/containers/tutor-home-page/language-step/LanguageStep.spec.jsx
@@ -1,8 +1,28 @@
 import { cleanup, render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
 import LanguageStep from '~/containers/tutor-home-page/language-step/LanguageStep'
 import { StepProvider } from '~/context/step-context'
+import useAxios from '~/hooks/use-axios'
+
 const mockBtnsBox = <div>Mock Buttons Box</div>
-import { vi } from 'vitest'
+
+const languages = [
+  'English',
+  'Ukrainian',
+  'Polish',
+  'German',
+  'French',
+  'Spanish',
+  'Arabic'
+]
+
+const fakeData = {
+  error: null,
+  loading: false,
+  response: languages
+}
+
+vi.mock('~/hooks/use-axios')
 
 vi.mock('~/context/step-context', () => ({
   useStepContext: () => ({
@@ -12,9 +32,16 @@ vi.mock('~/context/step-context', () => ({
   StepProvider: vi.fn(({ children }) => <div>{children}</div>)
 }))
 
+vi.mock('~/services/language-service', () => ({
+  languageService: {
+    getLanguages: () => {}
+  }
+}))
+
 describe('LanguageStep test', () => {
   beforeEach(() => {
     cleanup()
+    useAxios.mockImplementation(() => fakeData)
     render(
       <StepProvider>
         <LanguageStep btnsBox={mockBtnsBox} stepLabel='language' />


### PR DESCRIPTION
- Added fetching languages from backend to the `LanguageStep` component.
- Added mocks to the tests accordingly.
- Created `language-service.js`.
- Changed initial value for language in `step-context` due to MUI warning.

<img width="742" alt="image" src="https://github.com/Space2Study-UA-1125/frontEnd/assets/110097862/3c896e0f-1737-4837-acfb-4c66d16a5a2e">
