### PR TITLE
validation for firstName and LastName

### DIFF
--- a/src/components/step-wrapper/StepWrapper.jsx
+++ b/src/components/step-wrapper/StepWrapper.jsx
@@ -21,6 +21,9 @@ const StepWrapper = ({ children, steps }) => {
   const { stepData } = useStepContext()
   const [generalLabel, subjectLabel, languageLabel, photoLabel] = steps
 
+  const { errors } = stepData[generalLabel]
+  const hasErrors = Object.values(errors).some((error) => error !== '')
+
   const handleFinishBtnClick = () => {
     const stepDataforService = {
       firstName: stepData[generalLabel].data.firstName,
@@ -59,7 +62,13 @@ const StepWrapper = ({ children, steps }) => {
       {t('common.finish')}
     </AppButton>
   ) : (
-    <AppButton onClick={next} size='small' sx={styles.btn} variant='contained'>
+    <AppButton
+      disabled={hasErrors}
+      onClick={next}
+      size='small'
+      sx={styles.btn}
+      variant='contained'
+    >
       {t('common.next')}
       <EastIcon fontSize='small' />
     </AppButton>

--- a/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
+++ b/src/containers/tutor-home-page/general-info-step/GeneralInfoStep.jsx
@@ -18,8 +18,14 @@ import { useStepContext } from '~/context/step-context'
 const GeneralInfoStep = ({ btnsBox, stepLabel }) => {
   const { stepData, handleStepData } = useStepContext()
   const { t } = useTranslation()
-  const { firstName, lastName, updateFirstName, updateLastName } =
-    useUserName('')
+  const {
+    firstName,
+    lastName,
+    updateFirstName,
+    updateLastName,
+    firstNameError,
+    lastNameError
+  } = useUserName('')
   const [country, setCountry] = useState(stepData[stepLabel].data.country)
   const [city, setCity] = useState(stepData[stepLabel].data.city)
   const [professionalSummary, setProfessionalSummary] = useState(
@@ -47,13 +53,20 @@ const GeneralInfoStep = ({ btnsBox, stepLabel }) => {
     setCity(value)
   }
   useEffect(() => {
-    handleStepData(stepLabel, {
-      firstName,
-      lastName,
-      country,
-      city,
-      professionalSummary
-    })
+    handleStepData(
+      stepLabel,
+      {
+        firstName,
+        lastName,
+        country,
+        city,
+        professionalSummary
+      },
+      {
+        firstNameError,
+        lastNameError
+      }
+    )
   }, [
     firstName,
     lastName,
@@ -61,7 +74,9 @@ const GeneralInfoStep = ({ btnsBox, stepLabel }) => {
     city,
     professionalSummary,
     handleStepData,
-    stepLabel
+    stepLabel,
+    firstNameError,
+    lastNameError
   ])
   return (
     <Box sx={styles.container}>
@@ -81,6 +96,7 @@ const GeneralInfoStep = ({ btnsBox, stepLabel }) => {
         <Box sx={styles.dataContainer}>
           <AppTextField
             autoFocus
+            errorMsg={t(firstNameError)}
             label={t('common.labels.firstName*')}
             name='firstName'
             onChange={(event) => updateFirstName(event.target.value)}
@@ -88,6 +104,7 @@ const GeneralInfoStep = ({ btnsBox, stepLabel }) => {
           />
           <AppTextField
             autoFocus
+            errorMsg={t(lastNameError)}
             label={t('common.labels.lastName*')}
             name='lastName'
             onChange={(event) => updateLastName(event.target.value)}

--- a/src/hooks/use-user-name.jsx
+++ b/src/hooks/use-user-name.jsx
@@ -3,11 +3,12 @@ import { userService } from '~/services/user-service'
 import { useSelector } from 'react-redux'
 import { tutorStepLabels } from '~/components/user-steps-wrapper/constants'
 import { useStepContext } from '~/context/step-context'
+import { firstName, lastName } from '~/utils/validations/login'
 
 const useUserName = () => {
   const { stepData } = useStepContext()
-  const [firstName, setFirstName] = useState('')
-  const [lastName, setLastName] = useState('')
+  const [firstNameValue, setFirstName] = useState('')
+  const [lastNameValue, setLastName] = useState('')
   const store = useSelector((state) => state.appMain)
   const stepContextUserData = stepData[tutorStepLabels[0]].data
 
@@ -34,8 +35,17 @@ const useUserName = () => {
   const updateLastName = (newLastName) => {
     setLastName(newLastName)
   }
+  const firstNameError = firstName(firstNameValue)
+  const lastNameError = lastName(lastNameValue)
 
-  return { firstName, lastName, updateFirstName, updateLastName }
+  return {
+    firstName: firstNameValue,
+    lastName: lastNameValue,
+    updateFirstName,
+    updateLastName,
+    firstNameError,
+    lastNameError
+  }
 }
 
 export default useUserName

--- a/tests/unit/hooks/use-user-name.spec.jsx
+++ b/tests/unit/hooks/use-user-name.spec.jsx
@@ -20,6 +20,7 @@ vi.mock('~/context/step-context', () => ({
   }),
   StepProvider: vi.fn(({ children }) => <div>{children}</div>)
 }))
+
 const mockState = { userId: '1', userRole: 'tutor' }
 vi.mock('react-redux', async () => {
   const actual = await vi.importActual('react-redux')
@@ -40,7 +41,6 @@ vi.mock('~/services/user-service', () => ({
 describe('useUserName', () => {
   it('should fetch user data and update first and last names', async () => {
     const { result, waitForNextUpdate } = renderHook(() => useUserName())
-
     await waitForNextUpdate()
 
     expect(result.current.firstName).toBe('John')
@@ -48,9 +48,7 @@ describe('useUserName', () => {
   })
 
   it('should update first name', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useUserName())
-
-    await waitForNextUpdate()
+    const { result } = renderHook(() => useUserName())
 
     act(() => {
       result.current.updateFirstName('Jane')
@@ -60,9 +58,7 @@ describe('useUserName', () => {
   })
 
   it('should update last name', async () => {
-    const { result, waitForNextUpdate } = renderHook(() => useUserName())
-
-    await waitForNextUpdate()
+    const { result } = renderHook(() => useUserName())
 
     act(() => {
       result.current.updateLastName('Smith')


### PR DESCRIPTION
Add validation to required fields in General Info step for both student and tutor steppers

- First name and Last name fields must be required and show an error when user removed text from them.
https://www.loom.com/share/dab1c1b8c11b4d7681773ed1fb474047?sid=66ecdfac-9a1a-4b20-bb63-22eaa7d1fed3

- Length of additional info can't be more than 100 symbols and block texting when it reached limit - was implemented before

- When there are errors in fields stepper can't be switched to the next steps