### PR TITLE
Put all the blocks into one page Categories, adjusted the logic and tests

### DIFF
--- a/src/assets/mui-icons/mui-icons.jsx
+++ b/src/assets/mui-icons/mui-icons.jsx
@@ -35,9 +35,9 @@ const icons = {
     'History': <HistoryIcon />,
     'Computer science': <ComputerIcon />,
     'Mathematics': <TagIcon />,
+    'Design': <DesignServicesIcon />,
     'Art': <DesignServicesIcon />,
     'Dark Arts': <AutoFixHighIcon />,
-    'Design': <DesignServicesIcon />,
     'Economics': <PlagiarismIcon />
 }
 

--- a/src/components/categories-list/CategoriesList.jsx
+++ b/src/components/categories-list/CategoriesList.jsx
@@ -83,7 +83,7 @@ const CategoriesList = ({ searchedCategories }) => {
                 category.totalOffers.student + category.totalOffers.tutor
               }
               title={category.name}
-              to={`${authRoutes.subjectsCategoryId.path}/${category._id}/subjects`}
+              to={`${authRoutes.offersCategoryName.path}/${category.name}/offers`}
             />
           </Grid>
         ))}

--- a/src/components/request-new-category-subject/RequestNewCategorySubject.jsx
+++ b/src/components/request-new-category-subject/RequestNewCategorySubject.jsx
@@ -1,0 +1,35 @@
+import Link from '@mui/material/Link'
+import Typography from '@mui/material/Typography'
+import Box from '@mui/material/Box'
+import { useTranslation } from 'react-i18next'
+import { styles } from '~/components/request-new-category-subject/RequestNewCategorySubject.styles'
+
+const RequestNewCategorySubject = () => {
+  const { t } = useTranslation()
+  const textParts = t('categoriesPage.newSubject.categoryOrSubject').split(
+    /(category|subject)/i
+  )
+
+  return (
+    <Box sx={styles.container}>
+      <Typography component='span'>
+        {textParts.map((part, index) => {
+          if (
+            part.toLowerCase() === 'category' ||
+            part.toLowerCase() === 'subject'
+          ) {
+            return (
+              <Link key={index} sx={styles.colorGray} to='/'>
+                {part}
+              </Link>
+            )
+          } else {
+            return part
+          }
+        })}
+      </Typography>
+    </Box>
+  )
+}
+
+export default RequestNewCategorySubject

--- a/src/components/request-new-category-subject/RequestNewCategorySubject.styles.js
+++ b/src/components/request-new-category-subject/RequestNewCategorySubject.styles.js
@@ -1,0 +1,9 @@
+export const styles = {
+  colorGray: {
+    color: 'primary.500'
+  },
+  container: {
+    mb: '40px',
+    textAlign: 'center'
+  }
+}

--- a/src/constants/translations/en/categories-page.json
+++ b/src/constants/translations/en/categories-page.json
@@ -12,6 +12,7 @@
     "subject": "Create a new subject",
     "category": "Add subject to existing category or create a new one.",
     "info": "Provide a brief explanation of why you believe this subject or category should be added.",
+    "categoryOrSubject": "Can't find what you're looking for? Request a new category or subject!",
     "labels": { "subject": "New subject" }
   },
   "itemCard": {

--- a/src/containers/categories-search/CategoriesSearch.jsx
+++ b/src/containers/categories-search/CategoriesSearch.jsx
@@ -12,10 +12,10 @@ import { authRoutes } from '~/router/constants/authRoutes'
 import { categoryService } from '~/services/category-service'
 import AppAutoComplete from '~/components/app-auto-complete/AppAutoComplete'
 
-const CategoriesSearch = ({ categoryItems, setCategoryItems }) => {
+const CategoriesSearch = ({ onSearchResults }) => {
   const { t } = useTranslation()
   const [search, setSearch] = useState('')
-  const [options, setOptions] = useState(categoryItems)
+  const [options, setOptions] = useState([])
   const [showAutoComplete, setShowAutoComplete] = useState(false)
 
   useEffect(() => {
@@ -41,7 +41,7 @@ const CategoriesSearch = ({ categoryItems, setCategoryItems }) => {
   }
 
   const onSearch = () => {
-    setCategoryItems(options)
+    onSearchResults(options)
   }
 
   const onEnterPress = (event) => {

--- a/src/containers/categories-search/CategoriesSearch.styles.js
+++ b/src/containers/categories-search/CategoriesSearch.styles.js
@@ -12,7 +12,7 @@ export const styles = {
   },
   wrapper: {
     maxWidth: '1128px',
-    margin: '0 auto',
+    margin: '30px auto',
     marginBottom: '32px',
     textAlign: 'center'
   },

--- a/src/pages/categories/Categories.jsx
+++ b/src/pages/categories/Categories.jsx
@@ -3,15 +3,30 @@ import PageWrapper from '~/components/page-wrapper/PageWrapper'
 import Box from '@mui/material/Box'
 import CategoriesList from '~/components/categories-list/CategoriesList'
 import CategoriesSearch from '~/containers/categories-search/CategoriesSearch'
+import OfferRequestBlock from '~/components/offer-request-block/OfferRequestBlock'
+import RequestNewCategorySubject from '~/components/request-new-category-subject/RequestNewCategorySubject'
+import { useState } from 'react'
 import { styles } from '~/pages/categories/Categories.styles'
 
 const Categories = () => {
+  const [searchResults, setSearchResults] = useState([])
+  const [searchPerformed, setSearchPerformed] = useState(false)
+
+  const handleSearchResults = (results) => {
+    setSearchResults(results)
+    setSearchPerformed(true)
+  }
   return (
     <PageWrapper>
       <Box sx={styles.categoriesPageContainer}>
-        <CategoriesSearch />
-        <CategoriesList />
-        <NoResultsFound />
+        <OfferRequestBlock />
+        <CategoriesSearch onSearchResults={handleSearchResults} />
+        <RequestNewCategorySubject />
+        {searchPerformed && searchResults.length === 0 ? (
+          <NoResultsFound />
+        ) : (
+          <CategoriesList searchedCategories={searchResults} />
+        )}
       </Box>
     </PageWrapper>
   )

--- a/src/pages/categories/Categories.styles.js
+++ b/src/pages/categories/Categories.styles.js
@@ -1,1 +1,6 @@
-export const styles = {}
+export const styles = {
+  categoriesPageContainer: {
+    margin: '0 auto',
+    width: { xs: '288px', md: '696px', lg: '1128px' }
+  }
+}

--- a/src/router/constants/authRoutes.js
+++ b/src/router/constants/authRoutes.js
@@ -1,8 +1,8 @@
 export const authRoutes = {
   categories: { route: 'categories', path: '/categories' },
   subjects: { route: 'categories/subjects', path: '/categories/subjects' },
-  subjectsCategoryId: {
-    route: 'categories/:categoryId/:subject',
+  offersCategoryName: {
+    route: 'categories/:categoryName/:offers',
     path: '/categories'
   },
   chat: { route: 'chat', path: '/chat' },

--- a/src/router/routes/authRouter.jsx
+++ b/src/router/routes/authRouter.jsx
@@ -36,9 +36,9 @@ export const authRouter = (
       path={authRoutes.categories.route}
     />
     <Route
-      element={<Subjects />}
-      handle={{ crumb: [categories, subjects] }}
-      path={authRoutes.subjectsCategoryId.route}
+      element={<FindOffers />}
+      handle={{ crumb: [categories, findOffers] }}
+      path={authRoutes.offersCategoryName.route}
     />
     <Route
       element={<Subjects />}

--- a/tests/unit/components/categories-list/CategoriesList.spec.jsx
+++ b/tests/unit/components/categories-list/CategoriesList.spec.jsx
@@ -43,36 +43,7 @@ vi.mock('~/services/category-service', () => ({
               name: 'Category8',
               totalOffers: { student: 0, tutor: 1 }
             },
-            {
-              _id: 9,
-              name: 'Category9',
-              totalOffers: { student: 0, tutor: 1 }
-            },
-            {
-              _id: 10,
-              name: 'Category10',
-              totalOffers: { student: 0, tutor: 1 }
-            },
-            {
-              _id: 11,
-              name: 'Category11',
-              totalOffers: { student: 0, tutor: 1 }
-            },
-            {
-              _id: 12,
-              name: 'Category12',
-              totalOffers: { student: 0, tutor: 1 }
-            },
-            {
-              _id: 13,
-              name: 'Category13',
-              totalOffers: { student: 0, tutor: 1 }
-            },
-            {
-              _id: 14,
-              name: 'Category14',
-              totalOffers: { student: 0, tutor: 1 }
-            }
+            { _id: 9, name: 'Category9', totalOffers: { student: 0, tutor: 1 } }
           ]
         }
       }
@@ -81,23 +52,32 @@ vi.mock('~/services/category-service', () => ({
 }))
 
 describe('CategoriesList component test', () => {
-  beforeEach(() => {
-    renderWithProviders(<CategoriesList setQuantity={() => {}} />)
-  })
-
-  it('fetches and renders categories correctly', async () => {
+  it('renders fetched categories when searchedCategories is empty', async () => {
+    renderWithProviders(<CategoriesList searchedCategories={[]} />)
     await waitFor(() => {
       expect(screen.getByText('Category1')).toBeInTheDocument()
-      expect(screen.getByText('Category12')).toBeInTheDocument()
+    })
+  })
+
+  it('renders searched categories when searchedCategories is not empty', async () => {
+    const searchedCategories = [
+      { _id: 2, name: 'Category2', totalOffers: { student: 0, tutor: 1 } }
+    ]
+    renderWithProviders(
+      <CategoriesList searchedCategories={searchedCategories} />
+    )
+    await waitFor(() => {
+      expect(screen.getByText('Category2')).toBeInTheDocument()
     })
   })
 
   it('loads more categories when "View more" button is clicked', async () => {
+    renderWithProviders(<CategoriesList searchedCategories={[]} />)
     const viewMoreButton = screen.getByRole('button')
     fireEvent.click(viewMoreButton)
     await waitFor(() => {
-      expect(screen.getByText('Category1')).toBeInTheDocument()
-      expect(screen.getByText('Category13')).toBeInTheDocument()
+      const category9Elements = screen.getAllByText('Category9')
+      expect(category9Elements).toHaveLength(2)
     })
   })
 })

--- a/tests/unit/containers/categories-search/CategoriesSearch.spec.jsx
+++ b/tests/unit/containers/categories-search/CategoriesSearch.spec.jsx
@@ -71,12 +71,12 @@ describe('CategoriesSearch', () => {
       data: [{ name: 'category1' }, { name: 'category2' }]
     })
 
+    const handleSearchResults = vi.fn()
+
     const { getByText, getByPlaceholderText } = render(
-      <CategoriesSearch
-        categoryItems={[]}
-        setCategoryItems={setCategoryItems}
-      />
+      <CategoriesSearch onSearchResults={handleSearchResults} />
     )
+
     const inputElement = getByPlaceholderText('categoriesPage.searchLabel')
     const buttonElement = getByText('common.search')
 
@@ -84,7 +84,7 @@ describe('CategoriesSearch', () => {
     fireEvent.click(buttonElement)
 
     await waitFor(() => {
-      expect(categoryService.getCategories).toHaveBeenCalled()
+      expect(handleSearchResults).toHaveBeenCalled()
     })
   })
 })

--- a/tests/unit/pages/categories/Categories.spec.jsx
+++ b/tests/unit/pages/categories/Categories.spec.jsx
@@ -1,8 +1,7 @@
 import '@testing-library/jest-dom'
 import { renderWithProviders } from '~tests/test-utils'
-import { screen } from '@testing-library/react'
+import { screen, fireEvent, waitFor } from '@testing-library/react'
 import Categories from '~/pages/categories/Categories'
-
 
 vi.mock('~/components/page-wrapper/PageWrapper', () => {
   return {
@@ -10,6 +9,35 @@ vi.mock('~/components/page-wrapper/PageWrapper', () => {
     default: ({ children }) => <div>{children}</div>
   }
 })
+
+vi.mock('~/components/offer-request-block/OfferRequestBlock', () => {
+  return {
+    __esModule: true,
+    default: () => <div>OfferRequestBlock</div>
+  }
+})
+
+vi.mock('~/containers/categories-search/CategoriesSearch', () => {
+  return {
+    __esModule: true,
+    default: ({ onSearchResults }) => {
+      const handleSearch = () => {
+        onSearchResults([])
+      }
+      return <button onClick={handleSearch}>Search</button>
+    }
+  }
+})
+
+vi.mock(
+  '~/components/request-new-category-subject/RequestNewCategorySubject',
+  () => {
+    return {
+      __esModule: true,
+      default: () => <div>RequestNewCategorySubject</div>
+    }
+  }
+)
 
 vi.mock('~/components/categories-list/CategoriesList', () => {
   return {
@@ -30,13 +58,32 @@ describe('Categories Component', () => {
     renderWithProviders(<Categories />)
   })
 
-  it('should render the page', () => {
-    const categoriesText = screen.getByText(/CategoriesList/i)
-    expect(categoriesText).toBeInTheDocument()
+  it('should render OfferRequestBlock block', () => {
+    const offerRequestBlock = screen.getByText(/OfferRequestBlock/i)
+    expect(offerRequestBlock).toBeInTheDocument()
   })
 
-  it('should contain the text of the page in the document', () => {
-    const categoriesText = screen.getByText(/NoResultsFound/i)
-    expect(document.body.contains(categoriesText)).toBe(true)
+  it('should render CategoriesSearch block', () => {
+    const categoriesSearch = screen.getByText(/Search/i)
+    expect(categoriesSearch).toBeInTheDocument()
+  })
+
+  it('should render RequestNewCategorySubject block', () => {
+    const requestNewCategorySubject = screen.getByText(
+      /RequestNewCategorySubject/i
+    )
+    expect(requestNewCategorySubject).toBeInTheDocument()
+  })
+
+  it('should render CategoriesList block', () => {
+    const categoriesList = screen.getByText(/CategoriesList/i)
+    expect(categoriesList).toBeInTheDocument()
+  })
+
+  it('should render NoResultsFound block if there are no results after search', async () => {
+    fireEvent.click(screen.getByText(/Search/i))
+    await waitFor(() => {
+      expect(screen.getByText('NoResultsFound')).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
When a user opens categories page, then he/she can see the main block.
This block contains:
- Create request block
- the title "Category" with description below
- "Show all offers" button
- search input with "Search" button
- text with suggestion to send request to create a new subject/category
- list of all categories
- "View more" button
When a user clicks on the "Show all offers", he/she should be redirected to "find offers" page
When a user clicks on the "Search" button or press enter, search should be performed
When user clicks on category card, she/he should be redirected to "subjects" page with list of all subjects related to that category
"View more" button should render more cards
"View more" button should disapear if there are no more cards to display
"Sorry, no results found" block should display if there are no categories matching the search

I recorded a short video: https://www.loom.com/share/df8e3a0b1e2b4fb4bad085d886dc384a