### PR TITLE
Fix url params setting bug on Find Offers page

### DIFF
--- a/src/pages/find-offers/FindOffers.jsx
+++ b/src/pages/find-offers/FindOffers.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback } from 'react'
 import Stack from '@mui/material/Stack'
 import { useSelector } from 'react-redux'
 import { useTranslation } from 'react-i18next'
@@ -18,20 +18,16 @@ const FindOffers = () => {
   const { t } = useTranslation()
   const { searchParams, setUrlSearchParams } = useUrlSearchParams()
   const { userRole } = useSelector((state) => state.appMain)
-  const [view, setView] = useState(searchParams.get('view') || 'list')
-  const [sort, setSort] = useState(searchParams.get('sort') || 'createdAt')
-  const [authorRole, setAuthorRole] = useState(
-    searchParams.get('authorRole') ||
-      (userRole === 'student' ? 'tutor' : 'student')
-  )
 
-  useEffect(() => {
-    setUrlSearchParams({ view, sort, authorRole })
-  }, [view, sort, authorRole, setUrlSearchParams])
+  const authorRole =
+    searchParams.get('authorRole') ||
+    (userRole === 'student' ? 'tutor' : 'student')
+  const view = searchParams.get('view') || 'list'
+  const sort = searchParams.get('sort') || 'createdAt'
 
   const serviceFunction = useCallback(
-    () => offerService.getOffers({ authorRole }),
-    [authorRole]
+    () => offerService.getOffers({ authorRole, sort }),
+    [authorRole, sort]
   )
 
   const { response } = useAxios({
@@ -49,12 +45,16 @@ const FindOffers = () => {
   }
 
   const handleAuthorRoleChange = () => {
-    setAuthorRole(authorRole === 'student' ? 'tutor' : 'student')
+    const newAuthorRole = authorRole === 'student' ? 'tutor' : 'student'
+    setUrlSearchParams({ authorRole: newAuthorRole })
   }
 
   return (
     <PageWrapper>
-      <AppSortMenu setSort={setSort} sort={sort} />
+      <AppSortMenu
+        setSort={(sort) => setUrlSearchParams({ sort })}
+        sort={sort}
+      />
       <Stack sx={styles.stack}>
         <div />
         <AppContentSwitcher
@@ -64,7 +64,10 @@ const FindOffers = () => {
           switchOptions={switchOptions}
           typographyVariant={'body1'}
         />
-        <AppViewSwitcher setView={setView} view={view} />
+        <AppViewSwitcher
+          setView={(view) => setUrlSearchParams({ view })}
+          view={view}
+        />
       </Stack>
       {response &&
         response.items?.map(({ _id, title, authorRole }) => (

--- a/src/pages/find-offers/FindOffers.jsx
+++ b/src/pages/find-offers/FindOffers.jsx
@@ -51,10 +51,6 @@ const FindOffers = () => {
 
   return (
     <PageWrapper>
-      <AppSortMenu
-        setSort={(sort) => setUrlSearchParams({ sort })}
-        sort={sort}
-      />
       <Stack sx={styles.stack}>
         <div />
         <AppContentSwitcher
@@ -64,10 +60,16 @@ const FindOffers = () => {
           switchOptions={switchOptions}
           typographyVariant={'body1'}
         />
-        <AppViewSwitcher
-          setView={(view) => setUrlSearchParams({ view })}
-          view={view}
-        />
+        <Stack sx={styles.stackRightFilters}>
+          <AppSortMenu
+            setSort={(sort) => setUrlSearchParams({ sort })}
+            sort={sort}
+          />
+          <AppViewSwitcher
+            setView={(view) => setUrlSearchParams({ view })}
+            view={view}
+          />
+        </Stack>
       </Stack>
       {response &&
         response.items?.map(({ _id, title, authorRole }) => (

--- a/src/pages/find-offers/FindOffers.styles.js
+++ b/src/pages/find-offers/FindOffers.styles.js
@@ -4,6 +4,12 @@ export const styles = {
     flexDirection: 'row',
     justifyContent: 'space-between'
   },
+  stackRightFilters: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: '30px'
+  },
   switch: {
     display: { sm: 'none', md: 'flex' }
   }

--- a/tests/unit/pages/find-offers/FindOffers.spec.jsx
+++ b/tests/unit/pages/find-offers/FindOffers.spec.jsx
@@ -3,7 +3,6 @@ import { renderWithProviders } from '~tests/test-utils'
 import { vi } from 'vitest'
 
 import FindOffers from '~/pages/find-offers/FindOffers'
-import useUrlSearchParams from '~/hooks/use-url-search-params'
 
 const studentOffers = {
   data: {
@@ -25,8 +24,6 @@ const tutorOffers = {
 
 const handleListView = vi.fn()
 const handleGridView = vi.fn()
-
-vi.mock('~/hooks/use-url-search-params')
 
 vi.mock('~/services/offer-service', () => ({
   offerService: {
@@ -57,18 +54,9 @@ vi.mock('~/components/app-view-switcher/AppViewSwitcher', () => ({
   )
 }))
 
-const searchParamsData = {
-  searchParams: {
-    get: vi.fn()
-  },
-  setUrlSearchParams: vi.fn()
-}
-
 describe('FindOffersPage test', () => {
   beforeEach(() => {
     const preloadedState = { appMain: { userRole: 'student' } }
-
-    useUrlSearchParams.mockImplementation(() => searchParamsData)
     renderWithProviders(<FindOffers />, { preloadedState })
   })
 
@@ -90,10 +78,6 @@ describe('FindOffersPage test', () => {
 })
 
 describe('FindOffersPage offer cards rendering test', () => {
-  beforeEach(() => {
-    useUrlSearchParams.mockImplementation(() => searchParamsData)
-  })
-
   it('should render tutor offer cards if user role is "student"', async () => {
     const preloadedState = { appMain: { userRole: 'student' } }
     renderWithProviders(<FindOffers />, { preloadedState })


### PR DESCRIPTION
- Fixed a navigation bug that appeared when setting URL query parameters. Did this by removing unnecessary states.
- Removed the `useUrlSearchParams` hook mock from the test, as we discussed on Discord.

https://www.loom.com/share/13285978d31a45f3abec04196b00ed9f?sid=0c2f4a5f-2b62-47e0-a1de-4eaea31b2845